### PR TITLE
Initialize `atomo-input-money` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   "dependencies": {
     "csstype": "2.5.7",
     "lit-html": "0.12.0",
+    "preact": "8.3.1",
     "showdown": "1.8.7"
   },
   "devDependencies": {
-    "@types/showdown": "^1.7.5",
+    "@types/showdown": "1.7.5",
     "html-loader": "0.5.5",
     "html-webpack-plugin": "3.2.0",
     "http-server": "0.11.1",

--- a/src/button/icon-button.ts
+++ b/src/button/icon-button.ts
@@ -1,20 +1,20 @@
 import * as CSS from "csstype"
 
-import AtomoElement from "helpers/AtomoElement"
-import {required, requiredEnumeration} from "helpers/normalizers"
+import AtomoLitElement from "helpers/AtomoLitElement"
+import { enumeration, required, string } from 'helpers/normalizers'
 import {html} from "lit-html"
 import {Declaration, variable} from "styles"
 import {Icon, iconTypes} from "../icon/api"
 
 import {ActionEvent, IconButtonProps, states} from "./api"
 
-export default class AtomoIconButton extends AtomoElement<IconButtonProps, {}> {
+export default class AtomoIconButton extends AtomoLitElement<IconButtonProps, {}> {
   constructor() {
     super({
       props: {
-        type: requiredEnumeration(iconTypes),
-        state: requiredEnumeration(states),
-        label: required()
+        type: required(enumeration(iconTypes)),
+        state: required(enumeration(states)),
+        label: required(string())
       },
       state: {}
     })

--- a/src/button/text-button.ts
+++ b/src/button/text-button.ts
@@ -1,25 +1,29 @@
-import * as CSS from "csstype"
+import * as CSS from 'csstype'
 
-import AtomoElement from "helpers/AtomoElement"
-import {optionalEnumeration, required, requiredEnumeration} from "helpers/normalizers"
-import {html} from "lit-html"
-import {Declaration, variable} from "styles"
-import {Icon, iconTypes} from "../icon/api"
+import AtomoLitElement from 'helpers/AtomoLitElement'
+import { enumeration, required, string } from 'helpers/normalizers'
+import { html } from 'lit-html'
+import { Declaration, variable } from 'styles'
+import { Icon, iconTypes } from 'icon/api'
 
-import {ActionEvent, states, TextButtonProps, textButtonTypes} from "./api"
+import { ActionEvent, states, TextButtonProps, textButtonTypes } from './api'
 
-export default class AtomoTextButton extends AtomoElement<TextButtonProps, {}> {
+export default class AtomoTextButton extends AtomoLitElement<TextButtonProps, {}> {
   constructor() {
     super({
       props: {
-        type: requiredEnumeration(textButtonTypes),
-        state: requiredEnumeration(states),
-        label: required(),
-        leftIcon: optionalEnumeration(iconTypes),
-        rightIcon: optionalEnumeration(iconTypes)
+        type: required(enumeration(textButtonTypes)),
+        state: required(enumeration(states)),
+        label: required(string()),
+        leftIcon: enumeration(iconTypes),
+        rightIcon: enumeration(iconTypes)
       },
       state: {}
     })
+  }
+
+  static get observedAttributes() {
+    return ['type', 'state', 'label', 'leftIcon', 'rightIcon']
   }
 
   onAction() {

--- a/src/helpers/AtomoPreactElement.tsx
+++ b/src/helpers/AtomoPreactElement.tsx
@@ -1,0 +1,22 @@
+import { Component, ComponentChild, ComponentChildren, h, RenderableProps } from 'preact'
+import { Declaration, styles } from 'styles'
+
+export default abstract class AtomoPreactElement<Props, State> extends Component<Props, State> {
+  protected constructor(props: Props) {
+    super(props)
+  }
+
+  render(props: RenderableProps<Props>, state: Readonly<State>, context: any): ComponentChild {
+    // Unfortunately, with preact, we cannot return an array but always an element.
+    // So as a workaround, we add the `div.host` element to be able to encapsulate things.
+    // @ts-ignore
+    return <div class="host">
+      <style>{styles(this.styles(props, state, context))}</style>
+      {this.html(props, state, context)}
+    </div>
+  }
+
+  abstract styles(props?: RenderableProps<Props>, state?: Readonly<State>, context?: any): Declaration
+
+  abstract html(props?: RenderableProps<Props>, state?: Readonly<State>, context?: any): ComponentChildren
+}

--- a/src/helpers/normalization.ts
+++ b/src/helpers/normalization.ts
@@ -1,0 +1,23 @@
+export type PropsNormalizer<P> = {
+  [K in keyof P]: Normalizer<P[K]>
+}
+
+export type Normalizer<A> = (value: string | undefined) => A
+
+export function getNormalizedAttributeName(attributeName: string): string {
+  return attributeName.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)
+}
+
+export function getNormalizedPropName(propName: string): string {
+  return propName.replace(/-[a-z]/g, (match) => `${match.toUpperCase()}`)
+}
+
+export function normalizeAttribute<P>(normalizers: PropsNormalizer<P>, name: string, value: string | undefined | null) {
+  // @ts-ignore
+  const normalizer: Normalizer<any> = normalizers[name]
+  if (normalizer) {
+    return normalizer(value === null ? undefined : value)
+  } else {
+    return value
+  }
+}

--- a/src/helpers/normalizers.ts
+++ b/src/helpers/normalizers.ts
@@ -1,62 +1,75 @@
-import {Normalizer} from "./AtomoElement";
+import { Normalizer } from 'helpers/normalization'
 
-export function identity<A extends string>(): Normalizer<A | undefined> {
-  return (value: string | undefined) => value as A
-}
-
-export function required<A extends string>(): Normalizer<A> {
+export function required<A>(normalizer: Normalizer<A | undefined>, fallback?: A): Normalizer<A> {
   return (value: string | undefined) => {
-    if (value === undefined || value === "") {
-      console.warn("Attribute value is undefined, expected string")
-      return "" as A
+    const normalizedValue = normalizer(value)
+    if (normalizedValue === undefined) {
+      if (fallback) {
+        console.warn(`Attribute required but got undefined, fallback to ${fallback}`)
+        return fallback
+      } else {
+        throw 'Attribute required but got undefined. No fallback was given'
+      }
     } else {
-      return value as A
+      return normalizedValue
     }
   }
 }
 
-export function optionalEnumeration<A extends string>(acceptedValues: Array<A>): Normalizer<A | undefined> {
+export function optional<A>(normalizer: (value: string) => A): Normalizer<A | undefined> {
   return (value: string | undefined) => {
     if (value === undefined) {
       return undefined
-    } else if (acceptedValues.includes(value as A)) {
-      return value as A
     } else {
-      console.warn(`Attribute value is invalid, expected: ${acceptedValues.join(", ")}, got: ${value}.`)
-      return value as A
+      return normalizer(value)
     }
   }
 }
 
-export function requiredEnumeration<A extends string>(acceptedValues: Array<A>, defaultValue?: A): Normalizer<A> {
-  return (value: string | undefined) => {
-    if (value === undefined) {
-      console.warn(`Attribute is undefined, expected: ${acceptedValues.join(", ")}. Fallback to ${defaultValue}`)
-      return defaultValue as A
-    } else if (acceptedValues.includes(value as A)) {
-      return value as A
-    } else {
-      console.warn(`Attribute value is invalid, expected: ${acceptedValues.join(", ")}, got: ${value}. Fallback to ${defaultValue}`)
-      return defaultValue as A
-    }
-  }
+export function string<A extends string>(): Normalizer<A | undefined> {
+  return optional(value => value as A)
 }
 
 export function number(): Normalizer<number | undefined> {
+  return optional(value => {
+    const normalizedValue = Number(value)
+    if (Number.isNaN(normalizedValue)) {
+      console.warn(`Value ${value} is not a valid number`)
+    } else {
+      return Number(value)
+    }
+  })
+}
+
+export function enumeration<A extends string>(acceptedValues: Array<A>): Normalizer<A | undefined> {
+  return optional(value => {
+    if (acceptedValues.includes(value as A)) {
+      return value as A
+    } else {
+      console.warn(`Attribute value is invalid, expected: ${acceptedValues.join(', ')}, got: ${value}.`)
+      return value as A
+    }
+  })
+}
+
+export function boolean(fallback: boolean = true): Normalizer<boolean> {
   return (value: string | undefined) => {
     if (value === undefined) {
-      return undefined
+      return fallback
     } else {
-      const normalizedValue = Number(value)
-      if (Number.isNaN(normalizedValue)) {
-        console.warn(`Value ${value} is not a valid number`)
-      } else {
-        return Number(value)
-      }
+      return value === 'true'
     }
   }
 }
 
-export function boolean(): Normalizer<boolean> {
-  return (value: string | undefined) => !(value === undefined || value === "false")
+
+export function date(): Normalizer<Date | undefined> {
+  return optional(value => {
+    const normalizedDate = Date.parse(value)
+    if (Number.isNaN(normalizedDate)) {
+      return undefined
+    } else {
+      return new Date(normalizedDate)
+    }
+  })
 }

--- a/src/helpers/preact-wrapper.ts
+++ b/src/helpers/preact-wrapper.ts
@@ -1,0 +1,41 @@
+import { getNormalizedAttributeName, normalizeAttribute, PropsNormalizer } from 'helpers/normalization'
+import { ComponentFactory, h, render } from 'preact'
+
+export function preactWrapper<P>(preactComponent: ComponentFactory<P>, properties: PropsNormalizer<P>) {
+  return class extends HTMLElement {
+    private readonly shadow: ShadowRoot
+    private currentElement: Element | undefined
+
+    constructor() {
+      super()
+      this.shadow = this.attachShadow({ mode: 'open' })
+    }
+
+    static get observedAttributes() {
+      return Object.keys(properties)
+    }
+
+    connectedCallback() {
+      this.render()
+    }
+
+    attributeChangedCallback() {
+      this.render()
+    }
+
+    render() {
+      if (this.isConnected) {
+        this.currentElement = render(h(preactComponent, this.getProps()), this.shadow, this.currentElement)
+      }
+    }
+
+    getProps() {
+      const props: any = {}
+      Object.keys(properties).forEach(key => {
+        const attributeName = getNormalizedAttributeName(key)
+        props[key] = normalizeAttribute(properties, key, this.getAttribute(attributeName))
+      })
+      return props as P
+    }
+  }
+}

--- a/src/icon/icon.ts
+++ b/src/icon/icon.ts
@@ -1,9 +1,9 @@
-import AtomoElement from "helpers/AtomoElement"
-import {identity, requiredEnumeration} from "helpers/normalizers"
-import {Declaration} from "../styles"
+import AtomoLitElement from 'helpers/AtomoLitElement'
+import { enumeration, required, string } from 'helpers/normalizers'
+import { Declaration } from 'styles'
 
-import {IconProps, IconSize, iconSizes, iconTypes} from "./api"
-import {icons} from "./icons";
+import { IconProps, IconSize, iconSizes, iconTypes } from './api'
+import { icons } from './icons'
 
 type Sizes = {
   [K in IconSize]: number
@@ -14,13 +14,13 @@ const sizes: Sizes = {
   large: 25
 }
 
-export default class AtomoIcon extends AtomoElement<IconProps, {}> {
+export default class AtomoIcon extends AtomoLitElement<IconProps, {}> {
   constructor() {
     super({
       props: {
-        type: requiredEnumeration(iconTypes),
-        description: identity(),
-        size: requiredEnumeration(iconSizes)
+        type: required(enumeration(iconTypes)),
+        description: string(),
+        size: required(enumeration(iconSizes))
       },
       state: {}
     })

--- a/src/index.html
+++ b/src/index.html
@@ -128,6 +128,7 @@
     <li><a href="#global-configuration">Global configuration</a></li>
     <li><a href="#atomo-button">Button</a></li>
     <li><a href="#atomo-icon">Icon</a></li>
+    <li><a href="#atomo-input-money">Input money</a></li>
   </ul>
 </nav>
 
@@ -137,5 +138,6 @@ ${require('./doc/general-design.html')}
 ${require('./doc/global-variables.html')}
 ${require('./button/button.doc.html')}
 ${require('./icon/icon.doc.html')}
+${require('./input-money/input-money.doc.html')}
 </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import "./button"
 import "./icon"
 import "./input"
+import "./input-money"
 import "./uikit"

--- a/src/input-money/index.ts
+++ b/src/input-money/index.ts
@@ -1,0 +1,11 @@
+import { enumeration, number, required, string } from 'helpers/normalizers'
+import { preactWrapper } from 'helpers/preact-wrapper'
+import { default as AtomoInputMoney, Props } from './input-money'
+
+export type AtomoInputMoneyProps = Props
+
+customElements.define('atomo-input-money', preactWrapper(AtomoInputMoney, {
+  label: required(string()),
+  value: required(number()),
+  currency: required(enumeration(['euro', 'dollar']))
+}))

--- a/src/input-money/input-money.doc.html
+++ b/src/input-money/input-money.doc.html
@@ -1,0 +1,35 @@
+<section aria-labelledby="atomo-input-money">
+  <h2 id="atomo-input-money">Input money</h2>
+
+  <p>Input for monetary values</p>
+
+  <h3>How to configure it</h3>
+
+  <p>TODO</p>
+
+  <h3>Best practices</h3>
+
+  <div class="row">
+    <div class="col">
+      <h3 class="do">Do</h3>
+
+      <p>TODO</p>
+    </div>
+
+    <div class="col">
+      <h3 class="dont">Don't</h3>
+
+      <p>TODO</p>
+    </div>
+  </div>
+
+  <h3>Example</h3>
+
+  <atomo-input-money label="Total" value="3.5" currency="euro"></atomo-input-money>
+
+  ${require('./input-money.conf.html')}
+
+  <h3>Links</h3>
+
+  <p>TODO</p>
+</section>

--- a/src/input-money/input-money.tsx
+++ b/src/input-money/input-money.tsx
@@ -1,0 +1,80 @@
+import AtomoPreactElement from 'helpers/AtomoPreactElement'
+import { h } from 'preact'
+import { Declaration } from 'styles'
+import { normalizePartialNumber } from 'utils/number'
+
+type Currency = 'euro' | 'dollar'
+
+const currencySymbols: { [key in Currency]: string } = {
+  euro: '€',
+  dollar: '$'
+}
+
+export interface Props {
+  label: string
+  value: number
+  currency: Currency
+}
+
+interface State {
+  internalValue: string
+}
+
+export default class AtomoInputMoney extends AtomoPreactElement<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.setState({
+      internalValue: props.value.toString()
+    })
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    this.setState({
+      internalValue: nextProps.value.toString()
+    })
+  }
+
+  html(props: Props, state: State) {
+    return [
+      <label for="input">{props.label}</label>,
+      <div class="field">
+        <input
+          type="text"
+          id="input"
+          value={state.internalValue}
+          onInput={this.onInput}
+        />
+        <span>{currencySymbols[props.currency]}</span>
+      </div>
+    ]
+  }
+
+  styles(): Declaration {
+    return {
+      label: {
+        display: 'block'
+      },
+      '.field': {
+        display: 'flex',
+        width: '100%',
+        border: '1px solid #eee'
+      },
+      input: {
+        flexGrow: 1,
+        border: 'none',
+        padding: '5px'
+      },
+      span: {
+        padding: '5px'
+      }
+    }
+  }
+
+  onInput = (event: Event) => {
+    const input = event.target as HTMLInputElement
+    const normalizedValue = normalizePartialNumber(input.value)
+    this.setState({
+      internalValue: normalizedValue
+    })
+  }
+}

--- a/src/input/input-text.ts
+++ b/src/input/input-text.ts
@@ -1,7 +1,7 @@
 import * as CSS from "csstype"
-import AtomoElement from "helpers/AtomoElement"
+import AtomoLitElement from "helpers/AtomoLitElement"
+import { enumeration, number, required, string } from 'helpers/normalizers'
 import {html} from "lit-html"
-import {identity, number, required, requiredEnumeration} from "../helpers/normalizers"
 import {Declaration, variable} from "../styles"
 
 import {TextInputProps, textInputStates} from "./api"
@@ -10,17 +10,17 @@ interface State {
   internalValue: string
 }
 
-export default class AtomoInputText extends AtomoElement<TextInputProps, State> {
+export default class AtomoInputText extends AtomoLitElement<TextInputProps, State> {
   constructor() {
     super({
       props: {
-        id: required(),
-        name: required(),
-        label: required(),
-        value: identity(),
-        placeholder: required(),
+        id: required(string()),
+        name: required(string()),
+        label: required(string()),
+        value: string(),
+        placeholder: required(string()),
         maxLength: number(),
-        state: requiredEnumeration(textInputStates, "normal")
+        state: required(enumeration(textInputStates), "normal")
       },
       state: props => ({
         internalValue: props.value || ""

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+import * as numbers from "./number"
+
+export { numbers }

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,23 @@
+/**
+ * Accept:
+ * - 1
+ * - 1.2
+ * - 1,3
+ *
+ * Refuse:
+ * - 1.1.
+ * - 1..
+ * - 1,.
+ */
+export function normalizePartialNumber(value: string): string {
+  let result = value
+    .replace(/,/gi, '.')
+    .replace(/[^0-9.]/gi, '')
+  if (result.indexOf('.') !== -1) {
+    while (result.indexOf('.') !== result.lastIndexOf('.')) {
+      const lastIndexOfDot =result.lastIndexOf('.')
+      result = result.substring(0, lastIndexOfDot) + result.substring(lastIndexOfDot + 1)
+    }
+  }
+  return result
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": "src",
     "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "jsxFactory": "h",
     "lib": [
       "dom",
       "esnext"
@@ -11,6 +13,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "outDir": "build",
+    "paths": {
+      "react": ["typings/react"]
+    },
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,

--- a/typings/atomo.d.ts
+++ b/typings/atomo.d.ts
@@ -1,0 +1,11 @@
+import { TextButtonProps } from 'button/api'
+import { AtomoInputMoneyProps } from 'input-money'
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'atomo-text-button': TextButtonProps
+      'atomo-input-money': AtomoInputMoneyProps
+    }
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.ts$/,
+        test: /\.tsx?$/,
         use: "ts-loader",
         exclude: /node_modules/
       },
@@ -30,7 +30,7 @@ module.exports = {
       path.resolve('./src'),
       path.resolve('./node_modules')
     ],
-    extensions: [".ts"]
+    extensions: [".ts", ".tsx", ".js"]
   },
   output: {
     filename: "bundle.js",


### PR DESCRIPTION
We continue developments by introducing a simple `atomo-input-money` component.

We take this opportunity to use `preact` as a library.
It will bring:

- Type system
- Props and state lifecycle (instead of a homemade one)

However, because of web-components,
we need to encapsulate Preact component into a homemade wrapper.
To respect types, we also need to use normalizers.
So we take this opportunity to refactor the one already made.

This commit does the following:

- Install Preact
- Use it to create the component `atomo-input-money`
- Create a homemade structure to use styles and structure components
- Refactor normalizer
- Create a wrapper preact component <-> web component